### PR TITLE
Make AVX symbols to be strictly visible (fix build with gcc8)

### DIFF
--- a/source/common/vec/intrinsic_deblock_avx2.cc
+++ b/source/common/vec/intrinsic_deblock_avx2.cc
@@ -30,15 +30,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../common.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
 
+#include "../common.h"
+#include "intrinsic.h"
 
 #if !HIGH_BIT_DEPTH
 __m128i c_0_128;

--- a/source/common/vec/intrinsic_idct_avx2.cc
+++ b/source/common/vec/intrinsic_idct_avx2.cc
@@ -30,14 +30,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../common.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../common.h"
+#include "intrinsic.h"
 
 /* disable warnings */
 #pragma warning(disable:4127)  // warning C4127: 条件表达式是常量

--- a/source/common/vec/intrinsic_inter_pred.cc
+++ b/source/common/vec/intrinsic_inter_pred.cc
@@ -30,14 +30,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../common.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../common.h"
+#include "intrinsic.h"
 
 #if !HIGH_BIT_DEPTH
 /* ---------------------------------------------------------------------------

--- a/source/common/vec/intrinsic_inter_pred_avx2.cc
+++ b/source/common/vec/intrinsic_inter_pred_avx2.cc
@@ -30,14 +30,15 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../common.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../common.h"
+#include "intrinsic.h"
+
 #pragma warning(disable:4127)  // warning C4127: 条件表达式是常量
 
 #if !HIGH_BIT_DEPTH

--- a/source/common/vec/intrinsic_intra-pred_avx2.cc
+++ b/source/common/vec/intrinsic_intra-pred_avx2.cc
@@ -30,14 +30,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../common.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../common.h"
+#include "intrinsic.h"
 
 #if !HIGH_BIT_DEPTH
 

--- a/source/common/vec/intrinsic_pixel_avx.cc
+++ b/source/common/vec/intrinsic_pixel_avx.cc
@@ -30,14 +30,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../common.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../common.h"
+#include "intrinsic.h"
 
 /* ---------------------------------------------------------------------------
  */

--- a/source/common/vec/intrinsic_sao_avx2.cc
+++ b/source/common/vec/intrinsic_sao_avx2.cc
@@ -30,14 +30,14 @@
  *    For more information, contact us at sswang @ pku.edu.cn.
  */
 
-#include "../common.h"
-#include "intrinsic.h"
-
 #include <mmintrin.h>
 #include <emmintrin.h>
 #include <tmmintrin.h>
 #include <smmintrin.h>
 #include <immintrin.h>
+
+#include "../common.h"
+#include "intrinsic.h"
 
 #if !HIGH_BIT_DEPTH
 #ifdef _MSC_VER


### PR DESCRIPTION
`_mm256_insertf128_si256` and `_mm256_castsi128_si256` are undeclared in the scope of `source/common/vec/intrinsic.h`, which seems to be strictly not permitted by gcc8.

Fixes #9