### PR TITLE
Update .gitignore for Untracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Release/
 x64_Debug/
 x64_Release/
 build/linux/cavs2dec*
+build/linux/davs2*
 My*/
 *.user
 *.suo


### PR DESCRIPTION
After compiling on Linux, I'm left with 2 'Untracked files': 
* `build/linux/davs2`
* `build/linux/davs2_config.h`

This PR ignores them by using: `build/linux/davs2*`. This is helpful when updating the repo after compiling once before (i.e. `git pull` after previously running `./configure` & `make`).